### PR TITLE
Emit message on output shortly after the configuration is applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ This allows also to alter configurations **manually**.
 
 <a name="output"></a>
 ### Output ###
-The `config` node has no output data.
+A message with the current timestamp is emitted to the `config` node's output 100 ms after the configuration is applied.
+A short delay is needed for Node RED to finish configuring and wiring the nodes. 
 
 <a name="example"></a>
 ## Example ##

--- a/config.html
+++ b/config.html
@@ -68,7 +68,7 @@
             active:{value:true}
         },
         inputs: 1,
-        outputs: 0,
+        outputs: 1,
         icon: "inject.png",
         label: function() {
                 return this.name || "Config";

--- a/config.js
+++ b/config.js
@@ -41,6 +41,9 @@ module.exports = function(RED) {
                     node.context().global.set(property.p,value);
                 }
             });
+            setTimeout(function() {
+                node.send({payload: Date.now()});
+            }, 100);
         };
         if (n.active) node.configure(node);
 	


### PR DESCRIPTION
This pull requests changes the `config` node's behavior to emit a message with the current timestamp shorty after the configuration is applied.

A short delay (100 ms) is needed for Node RED to finish configuring and wiring the node - this behavior mimics the behavior of `inject` node.

Reasoning behind the change is as follows: I have several flows where I have to post-process the configuration (e.g. generate a list of MQTT topics to subscribe to - based on the values from the configuration node). I've been successfully handling this by running a periodic `inject` message every minute or so to trigger the post-processing so far. In one project, though, I need a much faster response times to eventual configuration changes and emitting a message after the configuration is reset seems the most appropriate way to achieve this.

